### PR TITLE
Fix for  Version 0.1.0 of minitest-handler  added a change that break…

### DIFF
--- a/files/default/test/client_test.rb
+++ b/files/default/test/client_test.rb
@@ -1,0 +1,17 @@
+require 'chef/mixin/shell_out'
+include Chef::Mixin::ShellOut
+require 'shellwords'
+
+# Documentation can be found here:
+#  https://github.com/seattlerb/minitest
+#  http://docs.seattlerb.org/minitest/
+
+
+# Basic tests
+class TestSensuSpec < MiniTest::Chef::TestCase
+  def test_sensu_spec_run
+    cmd = shell_out Shellwords.join([ "/usr/bin/sensu_spec", '-p', node['sensu_spec']['conf_dir'].to_s, '-r', node['sensu_spec']['retry_count'].to_s, '-s', node['sensu_spec']['retry_sleep'].to_s ])
+    assert_equal(cmd.exitstatus, 0)
+  end
+end
+


### PR DESCRIPTION
…s backward compatibility. The minitest-handler now only loads test files named _test.rb